### PR TITLE
GraphQL/CLI: Indicate which keys failed to stake in setStaking (#4467)

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -310,6 +310,54 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "lockedPublicKeys",
+              "description": "List of public keys that could not be used to stake because they were locked",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PublicKey",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentStakingKeys",
+              "description": "Returns the public keys that are now staking their funds",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PublicKey",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1758,7 +1806,7 @@
             },
             {
               "name": "setStaking",
-              "description": "Set keys you wish to stake with - silently fails if you pass keys corresponding to accounts that are either locked or in trackedAccounts",
+              "description": "Set keys you wish to stake with",
               "args": [
                 {
                   "name": "input",
@@ -5264,7 +5312,7 @@
             },
             {
               "name": "bestChain",
-              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip.",
+              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns null if the system is bootstrapping.",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1046,7 +1046,13 @@ let set_staking_graphql =
   Command.async ~summary:"Start producing blocks"
     (Cli_lib.Background_daemon.graphql_init pk_flag
        ~f:(fun graphql_endpoint public_key ->
-         let%map _ =
+         let print_message msg arr =
+           if not (Array.is_empty arr) then
+             printf "%s: %s\n" msg
+               (String.concat_array ~sep:", "
+                  (Array.map ~f:Public_key.Compressed.to_base58_check arr))
+         in
+         let%map result =
            Graphql_client.(
              Graphql_client.query_exn
                (Graphql_queries.Set_staking.make
@@ -1054,8 +1060,13 @@ let set_staking_graphql =
                   ()))
              graphql_endpoint
          in
-         printf "New block producer public key: %s\n"
-           (Public_key.Compressed.to_base58_check public_key) ))
+         print_message "Stopped staking with" (result#setStaking)#lastStaking ;
+         print_message
+           "❌ Failed to start staking with keys (try `coda accounts unlock` \
+            first)"
+           (result#setStaking)#lockedPublicKeys ;
+         print_message "Started staking with"
+           (result#setStaking)#currentStakingKeys ))
 
 let set_snark_worker =
   let open Command.Param in

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -77,6 +77,8 @@ module Decoders = struct
     Yojson.Basic.Util.to_string json
     |> Public_key.Compressed.of_base58_check_exn
 
+  let public_key_array = Array.map ~f:public_key
+
   let optional_public_key = Option.map ~f:public_key
 
   let uint64 json =

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -107,7 +107,9 @@ module Set_staking =
 {|
 mutation ($public_key: PublicKey) {
   setStaking(input : {publicKeys: [$public_key]}) {
-    lastStaking
+    lastStaking @bsDecoder(fn: "Decoders.public_key_array")
+    lockedPublicKeys @bsDecoder(fn: "Decoders.public_key_array")
+    currentStakingKeys @bsDecoder(fn: "Decoders.public_key_array")
     }
   }
 |}]

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -167,19 +167,6 @@ let reset_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let trust_system = config.trust_system in
   Trust_system.reset trust_system ip_address
 
-let replace_block_production_keys keys pks =
-  let kps =
-    List.filter_map pks ~f:(fun pk ->
-        let open Option.Let_syntax in
-        let%map kps =
-          Coda_lib.wallets keys |> Secrets.Wallets.find_unlocked ~needle:pk
-        in
-        (kps, pk) )
-  in
-  Coda_lib.replace_block_production_keypairs keys
-    (Keypair.And_compressed_pk.Set.of_list kps) ;
-  kps |> List.map ~f:snd
-
 let setup_user_command ~fee ~nonce ~valid_until ~memo ~sender_kp
     user_command_body =
   let payload =


### PR DESCRIPTION
* GraphQL: Indicate which keys failed to stake in setStaking

* Improve the setStaking CLI command

* Add hint to unlock

Co-authored-by: Brandon Kase <brandon.kase@gmail.com>
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
